### PR TITLE
Fix select call with array instead of variadic args

### DIFF
--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -24,6 +24,6 @@ final class Select extends AbstractSelect
      */
     protected function modifySelection(QueryBuilder $qb, array $selections): void
     {
-        $qb->select($selections);
+        $qb->select(...$selections);
     }
 }

--- a/tests/Query/SelectSpec.php
+++ b/tests/Query/SelectSpec.php
@@ -42,21 +42,21 @@ final class SelectSpec extends ObjectBehavior
 
     public function it_select_single_filed(QueryBuilder $qb): void
     {
-        $qb->select(['a.foo'])->shouldBeCalled()->willReturn($qb);
+        $qb->select('a.foo')->shouldBeCalled()->willReturn($qb);
         $this->modify($qb, 'a');
     }
 
     public function it_select_several_fields(QueryBuilder $qb): void
     {
         $this->beConstructedWith('foo', 'bar');
-        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled()->willReturn($qb);
+        $qb->select('b.foo', 'b.bar')->shouldBeCalled()->willReturn($qb);
         $this->modify($qb, 'b');
     }
 
     public function it_select_operand(QueryBuilder $qb): void
     {
         $this->beConstructedWith('foo', new Field('bar'));
-        $qb->select(['b.foo', 'b.bar'])->shouldBeCalled()->willReturn($qb);
+        $qb->select('b.foo', 'b.bar')->shouldBeCalled()->willReturn($qb);
         $this->modify($qb, 'b');
     }
 }


### PR DESCRIPTION
Doctrine 3 expects multiple args to be passed to `select(...)`. An array no longer works.